### PR TITLE
Specify factor level for yardstick

### DIFF
--- a/R/sim_metrics.R
+++ b/R/sim_metrics.R
@@ -347,6 +347,7 @@ sim_metrics_helper <-
                 signal %>% dplyr::mutate(truth = "signal"),
                 background %>% dplyr::mutate(truth = "background")
               ) %>%
+                # Note for yardstick: "signal" is the second factor level
                 dplyr::mutate(truth = as.factor(truth)) %>%
                 dplyr::mutate(signal_probrank = rank(sim) / dplyr::n()) %>%
                 dplyr::select(-sim) %>%
@@ -366,7 +367,11 @@ sim_metrics_helper <-
             data_retrieval,
             function(df) {
               df %>%
-                yardstick::average_precision(truth, signal_probrank) %>%
+                # Set `event_level` as "second" because "signal" is the second
+                # factor level in `truth`
+                yardstick::average_precision(truth,
+                                             signal_probrank,
+                                             event_level = "second") %>%
                 dplyr::pull(.estimate)
             }
           )

--- a/tests/testthat/test-sim_metrics.R
+++ b/tests/testthat/test-sim_metrics.R
@@ -93,7 +93,7 @@ test_that("`sim_metrics` works", {
         sim_median_i = 0.171754795930839,
         sim_mean_stat_ref_i = 0.101138990315028,
         sim_sd_stat_ref_i = 0.79702010493852,
-        sim_retrieval_average_precision_ref_i = 0.839614168724203,
+        sim_retrieval_average_precision_ref_i = 0.313080223425812,
         sim_retrieval_r_precision_ref_i = 0.206666666666667
       ),
       row.names = c(NA, -1L),
@@ -125,8 +125,8 @@ test_that("`sim_metrics` works", {
         sim_mean_stat_ref_i_median_i = 0.161240002427761,
         sim_sd_stat_ref_i_mean_i = 0.79702010493852,
         sim_sd_stat_ref_i_median_i = 0.80835316991924,
-        sim_retrieval_average_precision_ref_i_mean_i = 0.839614168724203,
-        sim_retrieval_average_precision_ref_i_median_i = 0.836290914792196,
+        sim_retrieval_average_precision_ref_i_mean_i = 0.313080223425812,
+        sim_retrieval_average_precision_ref_i_median_i = 0.300331570390394,
         sim_retrieval_r_precision_ref_i_mean_i = 0.206666666666667,
         sim_retrieval_r_precision_ref_i_median_i = 0.173333333333333
       ),
@@ -155,7 +155,7 @@ test_that("`sim_metrics` works", {
         sim_median_g = 0.287140533081703,
         sim_mean_stat_ref_g = 0.101138990315028,
         sim_sd_stat_ref_g = 0.835088742570834,
-        sim_retrieval_average_precision_ref_g = 0.448707854167539,
+        sim_retrieval_average_precision_ref_g = 0.579463680008832,
         sim_retrieval_r_precision_ref_g = 0.577037037037037
       ),
       row.names = c(NA, -1L),


### PR DESCRIPTION
`average_precision` was being computed incorrectly. It was reporting assuming `background` as the true class. 